### PR TITLE
feat: 레이아웃 및 UI 개선

### DIFF
--- a/src/app/(login)/signup/signup-form.tsx
+++ b/src/app/(login)/signup/signup-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
-import InputBox from "@/components/labeled-inputbox"
+import LabeledInputBox from "@/components/labeled-inputbox"
 import Link from "next/link"
 import AuthContainer from '../AuthContainer'
 
@@ -31,22 +31,22 @@ export function SignUpForm() {
             <form className="space-y-4" onSubmit={handleSubmit}>
                 {step === 1 && (
                     <>
-                        <InputBox label="이메일" type="email">
+                        <LabeledInputBox label="이메일" type="email">
                             you@example.com
-                        </InputBox>
-                        <InputBox label="비밀번호" type="password" />
-                        <InputBox label="비밀번호 확인" type="password"/>
+                        </LabeledInputBox>
+                        <LabeledInputBox label="비밀번호" type="password" />
+                        <LabeledInputBox label="비밀번호 확인" type="password"/>
                     </>
                 )}
 
                 {step === 2 && (
                     <>
-                        <InputBox label="회사명" type="string" />
-                        <InputBox label="대표자명" type="string" />
-                        <InputBox label="사업자 등록번호" type="string" />
-                        <InputBox label="대표번호" type="string" />
-                        <InputBox label="담당자명" type="string" />
-                        <InputBox label="전화번호" type="string" />
+                        <LabeledInputBox label="회사명" type="string" />
+                        <LabeledInputBox label="대표자명" type="string" />
+                        <LabeledInputBox label="사업자 등록번호" type="string" />
+                        <LabeledInputBox label="대표번호" type="string" />
+                        <LabeledInputBox label="담당자명" type="string" />
+                        <LabeledInputBox label="전화번호" type="string" />
                     </>
                 )}
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,38 +11,38 @@ type Props = {
 
 export default function Page({ companyName, managerName }: Props) {
   return (
-<div className="flex flex-col justify-center w-full gap-4 min-h-auto md:p-4 bg-(--color-background) ">
-			<div className="flex flex-row justify-center w-full min-h-auto">
-				<Card className="flex w-full">
-					<CardContent>
-						<form>
-							<p className="pb-2">회사명: {companyName} </p>
-							<p>담당자 이름: {managerName} </p>
-						</form>
-					</CardContent>
-				</Card>
-			</div>
-			<div className="grid flex-wrap w-full grid-flow-col gap-4 overflow-hidden bg-amber-950">
-					<ChartAreaInteractive label="Title" />
-          <ChartAreaInteractive label="Title" />
-          <ChartAreaInteractive label="Title" />
-          <ChartAreaInteractive label="Title" />
-          <Card className='w-20'>
-            <CardContent>
-              dfdg
-            </CardContent>
-          </Card>
-          <Card className='w-20'>
-            <CardContent>
-              dfdg
-            </CardContent>
-          </Card>
-          <Card className='w-20'>
-            <CardContent>
-              dfdg
-            </CardContent>
-          </Card>
-			</div>
-		</div>
+    <div className="flex flex-col justify-center w-full gap-4 min-h-auto md:p-4 bg-(--color-background) ">
+      <div className="flex flex-row justify-center w-full min-h-auto">
+        <Card className="flex w-full">
+          <CardContent>
+            <form>
+              <p className="pb-2">회사명: {companyName} </p>
+              <p>담당자 이름: {managerName} </p>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        <ChartAreaInteractive label="Title" />
+        <ChartAreaInteractive label="Title" />
+        <ChartAreaInteractive label="Title" />
+        <ChartAreaInteractive label="Title" />
+        <Card className='w-full'>
+          <CardContent>
+            dfdg
+          </CardContent>
+        </Card>
+        <Card className='w-full'>
+          <CardContent>
+            dfdg
+          </CardContent>
+        </Card>
+        <Card className='w-full'>
+          <CardContent>
+            dfdg
+          </CardContent>
+        </Card>
+      </div>
+    </div>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
       >
         <div className="flex flex-col w-full overflow-hidden min-h-full">
           <NaviBar />
-          <main className="w-full overflow-hidden">
+          <main className="w-full overflow-hidden pt-16">
             {children}
           </main>
         </div>

--- a/src/app/mypage/account/account-form.tsx
+++ b/src/app/mypage/account/account-form.tsx
@@ -27,7 +27,7 @@ export default function AccountForm() {
   };
 
   return (
-    <form className="space-y-4" onSubmit={handleSubmit}>
+    <form className="space-y-6 w-full max-w-4xl" onSubmit={handleSubmit}>
       <LabeledInputBox
         label="담당자 이름"
         name="name"
@@ -35,6 +35,9 @@ export default function AccountForm() {
         value={formData.name}
         onChange={handleChange}
         direction="row"
+        width="w-[400px]"
+        labelWidth="w-[100px]"
+        className="gap-4"
       />
       <LabeledInputBox
         label="이메일"
@@ -43,6 +46,9 @@ export default function AccountForm() {
         value={formData.email}
         onChange={handleChange}
         direction="row"
+        width="w-[400px]"
+        labelWidth="w-[100px]"
+        className="gap-4"
       />
       <LabeledInputBox
         label="비밀번호"
@@ -51,6 +57,9 @@ export default function AccountForm() {
         value={formData.password}
         onChange={handleChange}
         direction="row"
+        width="w-[400px]"
+        labelWidth="w-[100px]"
+        className="gap-4"
       />
       <LabeledInputBox
         label="비밀번호 확인"
@@ -59,6 +68,9 @@ export default function AccountForm() {
         value={formData.confirmPassword}
         onChange={handleChange}
         direction="row"
+        width="w-[400px]"
+        labelWidth="w-[100px]"
+        className="gap-4"
       />
       <LabeledInputBox
         label="휴대전화"
@@ -67,12 +79,15 @@ export default function AccountForm() {
         value={formData.phone}
         onChange={handleChange}
         direction="row"
+        width="w-[400px]"
+        labelWidth="w-[100px]"
+        className="gap-4"
       />
 
       <div className="flex justify-end">
         <Button
           type="submit"
-          className="w-1/8 mt-4 bg-black text-white hover:bg-white hover:text-black border border-black"
+          className="w-[100px] mt-4 bg-black text-white hover:bg-white hover:text-black border border-black"
         >
           저장
         </Button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,7 @@
 import { Button } from "@/components/ui/button";
-import { ChartNoAxesCombined, Lightbulb, BarChart3, Users, Building2 } from "lucide-react"
+import { ChartNoAxesCombined, Lightbulb, BarChart3, Users, Building2, Building, User } from "lucide-react"
 
 export default function Page() {
-  const menuItems = [
-    { title: "담당자 정보", url: "/", icon: User },
-    { title: "회사 정보", url: "/mypage/company", icon: Building },
-  ];
 
   return (
     <div className="w-full overflow-hidden">

--- a/src/components/NaviBar.tsx
+++ b/src/components/NaviBar.tsx
@@ -25,7 +25,7 @@ export default function NaviBar() {
   }, []);
 
   return (
-    <NavigationMenu className="sticky top-0 bg-white shadow-sm min-w-full">
+    <NavigationMenu className="fixed top-0 left-0 right-0 bg-white shadow-sm min-w-full z-50">
       <div className="w-full max-w-screen-xl mx-auto px-4">
         <div className="flex w-full justify-between items-center h-16">
           <NavigationMenu>

--- a/src/components/labeled-inputbox.tsx
+++ b/src/components/labeled-inputbox.tsx
@@ -1,45 +1,46 @@
-import { Label } from "@/components/ui/label";
+import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
-import React from "react";
+import { cn } from "@/lib/utils"
+import React from "react"
 
 type LabeledInputBoxProps = {
-  label: string;
+  label: string
   name?: string;
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value?: string;
+  children?: string
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   className?: string;
   type: string;
   direction?: "row" | "col";
-};
+  width?: string;
+  labelWidth?: string;
+}
 
 export default function LabeledInputBox({
   label,
   name,
   value,
+  children,
   onChange,
   className,
   type,
   direction = "col",
+  width,
+  labelWidth,
 }: LabeledInputBoxProps) {
   return (
-    <div
-      className={cn(
-        `flex ${
-          direction === "row" ? "items-center gap-2" : "flex-col"
-        } ${className} flex justify-between w-full`
-      )}
-    >
-      <Label>{label}</Label>
+    <div className={cn(`flex gap-1 ${direction === "col" ? "flex-col" : "flex-row items-center"}`, className)}>
+      <Label className={cn("text-gray-700 font-medium", labelWidth)}>{label}</Label>
       <Input
         id={name}
         name={name}
         type={type}
+        placeholder={children}
+        className={cn("border rounded py-2 px-3 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 focus:outline-none", width)}
         value={value}
         onChange={onChange}
         required
-        className="max-w-75"
       />
     </div>
-  );
+  )
 }


### PR DESCRIPTION
- 네비게이션 바를 스크롤 시에도 상단에 고정되도록 수정
- 입력 컴포넌트의 레이아웃 옵션 개선 (라벨/입력폼 너비 조절 가능)
- 계정관리 페이지의 입력폼 정렬 및 일관성 개선
- 대시보드의 카드 레이아웃을 반응형으로 개선